### PR TITLE
Glitchと協働してディスコードボットからスクリプトを実行できるように変更

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -1,7 +1,10 @@
 {
   "timeZone": "Asia/Tokyo",
-  "dependencies": {
-  },
+  "dependencies": {},
   "exceptionLogging": "STACKDRIVER",
-  "runtimeVersion": "V8"
+  "runtimeVersion": "V8",
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE_ANONYMOUS"
+  }
 }

--- a/テスト.gs
+++ b/テスト.gs
@@ -1,0 +1,16 @@
+function myFunction() {
+  const WEBHOOK_URL = 'https://discord.com/api/webhooks/1176695188077420544/k0n60vT8KA3Qx8m1J_glADbpg9kt_vo7du8d9Ea3tiDK3AiFZ2TOgOngtI4byW0LrncA';
+
+    const payload = {
+      username: "たかし💀",
+      content: "やれや",
+
+    }
+
+      UrlFetchApp.fetch(WEBHOOK_URL, {
+      method: 'post',
+      contentType: 'application/json',
+      payload: JSON.stringify(payload),
+
+    });
+}

--- a/ボット応答処理.gs
+++ b/ボット応答処理.gs
@@ -1,0 +1,93 @@
+const setURL = () => P.set('glitchURL', 'https://nonchalant-superficial-krill.glitch.me');
+
+//GASのプロパティを使いやすいように
+//プロパティを使うことで機密情報のべた書きを避ける
+const P = {
+  prop: PropertiesService.getScriptProperties(),
+  get(key) {
+    return this.prop.getProperty(key);
+  },
+  set(key, value) {
+    this.prop.setProperty(key, value);
+  }
+}
+
+
+//5分おきにこの関数を実行するように時限トリガーを設定
+const retainGlitch = () => {
+  //あらかじめ設定しておいたプロパティを呼び出す
+  const glitchURL = P.get('glitchURL')
+
+  const data = {}
+  const headers = { 'Content-Type': 'application/json; charset=UTF-8' }
+  const params = {
+    method: 'post',
+    payload: JSON.stringify(data),
+    headers: headers,
+    muteHttpExceptions: true
+  }
+  //特に中身のないデータをGlitchへPOST
+  response = UrlFetchApp.fetch(glitchURL, params);
+  console.log(response);
+}
+
+function doGet(e) {
+  return HtmlService.createHtmlOutput('Hello, world!');
+}
+
+//Glitchからのメッセージが入ったPOSTを受け取る
+const doPost = e => {
+  const message = JSON.parse(e.postData.contents);
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+
+  let messageObj
+
+  if (message.content.startsWith("勤務開始：")) {
+    const restOfMessage = message.content.slice("勤務開始：".length).trim(); // メッセージから「勤務開始」を取り除いてトリム
+
+    // ここで restOfMessage を使って必要な処理を実行
+    startBotTimeData(restOfMessage, message.author.username);
+
+    // 返信データを作成
+    messageObj = {
+      'messageType': 'send',
+      'content': '計測を開始したよ！😊'
+    };
+  }
+  else if (message.content.startsWith("勤務終了")) {
+    endTimeData(message.author.username);
+
+    // 返信データを作成
+    messageObj = {
+      'messageType': 'send',
+      'content': '計測を終了したよ！🥰'
+    };
+  }
+  else {
+    //返信データを作成
+    messageObj = {
+      'messageType': 'nothing',
+      'content': message.content
+    }
+  }
+
+
+  const payload = JSON.stringify(messageObj);
+
+  //json形式データを返す
+  const output = ContentService.createTextOutput().setMimeType(ContentService.MimeType.JSON);
+  return output.setContent(payload);
+};
+
+// ログをファイルに書き出す関数
+function appendLogToFile(logMessage) {
+  const fileName = 'log.txt';
+  const folder = DriveApp.getRootFolder();
+  const file = folder.getFilesByName(fileName).next();
+
+  // ファイルが存在する場合は開き、存在しない場合は新規作成
+  const logFile = file ? file : folder.createFile(fileName, logMessage);
+
+  // ファイルにログを追記
+  logFile.setContent(logFile.getBlob().getDataAsString() + '\n' + logMessage);
+}

--- a/ボット応答処理.gs
+++ b/ボット応答処理.gs
@@ -39,11 +39,12 @@ function doGet(e) {
 const doPost = e => {
   const message = JSON.parse(e.postData.contents);
   var sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  // sheet.getRange(1, 5).setValue(message);
 
   let messageObj
 
-  if (message.content.startsWith("勤務開始：")) {
-    const restOfMessage = message.content.slice("勤務開始：".length).trim(); // メッセージから「勤務開始」を取り除いてトリム
+  if (message.content.startsWith("勤務開始/")) {
+    const restOfMessage = message.content.slice("勤務開始/".length).trim(); // メッセージから「勤務開始」を取り除いてトリム
 
     // ここで restOfMessage を使って必要な処理を実行
     startBotTimeData(restOfMessage, message.author.username);

--- a/勤怠入力.gs
+++ b/勤怠入力.gs
@@ -58,12 +58,50 @@ function startTimeData() {
     var description = 'キャンセルされました';
     Browser.msgBox(description);
   }
+}
 
+function startBotTimeData(message, userId){
+  // シート名の生成
+  var sheetName = userId.startsWith('leaf6328') ? 'ミナリALL' : 'タガALL';
+  // シートの取得
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+  
+  // シートが存在しない場合は作成
+  if (!sheet) {
+    sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet(sheetName);
+    // シートのヘッダーなどを設定する処理があればここで行う
+  }
+
+  var tableRange = sheet.getRange('A9'); // テーブルの最初のセル
+
+  var date = new Date(); // 現在の日付と時刻を取得
+  date = roundDownTo15Minutes(date); // 15分単位で切り捨て
+  
+  // discordBot用に書き換え
+  var description = message
+  // 新しいデータを挿入する行を選択
+  var newRow = sheet.getRange('A9').getRow();
+  // 既存のデータを下にシフトさせる
+  sheet.insertRowsBefore(newRow, 1);
+  // テキストを業務内容として記録
+  sheet.getRange(tableRange.getRow(), 3).setValue(description);
+  tableRange.setValue(date);
 }
 
 
-function endTimeData() {
-  var sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+
+function endTimeData(userId) {
+  // シート名の生成
+  var sheetName = userId.startsWith('leaf6328') ? 'ミナリALL' : 'タガALL';
+  // シートの取得
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+
+  // シートが存在しない場合は作成
+  if (!sheet) {
+    sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet(sheetName);
+    // シートのヘッダーなどを設定する処理があればここで行う
+  }
+
   var tableRange = sheet.getRange('B9'); // テーブルの最初のセル
 
   var date = new Date(); // 現在の日付と時刻を取得


### PR DESCRIPTION
# ディスコードボットによる勤怠計測開始/終了の実行

- Glitch（https://glitch.com/edit/#!/nonchalant-superficial-krill）
- GAS（https://script.google.com/u/0/home/projects/1HE34rCTZ8DO6wOHPmHyl860lB4HrjtPZQsx_fRTcq8kVInWeDpNKhlV1/edit）

### ディスコードボットの実装
Glitchによって建てられたディスコードボットを実装．
決まってフレーズがユーザから送信された際に，文言に応じた挙動を実現
<img width="219" alt="image" src="https://github.com/FUJI-CORPORATION-GROUP/Attendance_format/assets/126942302/bbfe296a-d216-45f7-b722-7eae7e79c761">
<img width="214" alt="image" src="https://github.com/FUJI-CORPORATION-GROUP/Attendance_format/assets/126942302/6effba39-97d4-4858-b574-3aeeaf74c597">

### GASでの勤務時間測定
ディスコードでの送信内容に応じて開始/終了を検知

　開始 - "勤務開始：〇〇"
　終了 - "勤務終了"

勤務開始時は業務内容をコロン後に記述することで，スプレッドシート上の「業務内容」欄に書き込まれる
<img width="424" alt="image" src="https://github.com/FUJI-CORPORATION-GROUP/Attendance_format/assets/126942302/c3211c51-65ee-437e-903d-fe3dfbdc502b">


